### PR TITLE
Normalize role storage, harden splash/onboarding routing, and add Expo Android startup helpers

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -204,10 +204,15 @@ function AuthStateHandler() {
   useEffect(() => {
     // Check if onboarding is completed
     const checkOnboardingStatus = async () => {
-      const onboardingCompleted = await AsyncStorage.getItem(
-        "hasSeenOnboarding"
-      );
-      setHasCompletedOnboarding(onboardingCompleted === "true");
+      try {
+        const onboardingCompleted = await AsyncStorage.getItem(
+          "hasSeenOnboarding"
+        );
+        setHasCompletedOnboarding(onboardingCompleted === "true");
+      } catch (error) {
+        console.warn("Unable to read onboarding status:", error);
+        setHasCompletedOnboarding(false);
+      }
     };
     checkOnboardingStatus();
   }, []);
@@ -223,25 +228,38 @@ function AuthStateHandler() {
 
     // Check if user has selected a role
     const checkRoleSelection = async () => {
-      const selectedRole = await AsyncStorage.getItem("userRole");
+      try {
+        const [userRoleValue, selectedRoleValue] = await AsyncStorage.multiGet([
+          "userRole",
+          "selectedRole",
+        ]);
+        const selectedRole = userRoleValue[1] || selectedRoleValue[1];
 
-      if (selectedRole) {
-        // If role is selected, check authentication
-        if (isAuthenticated) {
-          // Redirect to appropriate home screen based on role
-          if (selectedRole === "merchant") {
-            router.replace("/merchant/home");
-          } else if (selectedRole === "driver") {
-            router.replace("/home/driver");
-          } else if (selectedRole === "consumer") {
-            router.replace("/home/consumer");
+        if (selectedRole) {
+          if (!userRoleValue[1]) {
+            await AsyncStorage.setItem("userRole", selectedRole);
+          }
+
+          // If role is selected, check authentication
+          if (isAuthenticated) {
+            // Redirect to appropriate home screen based on role
+            if (selectedRole === "merchant") {
+              router.replace("/home/merchant");
+            } else if (selectedRole === "driver") {
+              router.replace("/home/driver");
+            } else if (selectedRole === "consumer") {
+              router.replace("/home/consumer");
+            }
+          } else {
+            // If not authenticated, go to sign-in
+            router.replace("/auth/signin");
           }
         } else {
-          // If not authenticated, go to sign-in
-          router.replace("/auth/signin");
+          // If no role selected, go to role selection first
+          router.replace("/auth/role-selection");
         }
-      } else {
-        // If no role selected, go to role selection first
+      } catch (error) {
+        console.warn("Unable to resolve role selection:", error);
         router.replace("/auth/role-selection");
       }
     };

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,7 +5,9 @@ import { useRouter } from "expo-router";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SplashScreen from 'expo-splash-screen';
 
-SplashScreen.preventAutoHideAsync();
+void SplashScreen.preventAutoHideAsync().catch((error) => {
+  console.warn("Failed to keep native splash screen visible:", error);
+});
 
 export default function SplashScreenComponent() {
   const router = useRouter();
@@ -65,7 +67,8 @@ export default function SplashScreenComponent() {
         }
 
         // Step 2: Check if user has selected a role
-        const selectedRole = await AsyncStorage.getItem('selectedRole');
+        const [selectedRoleValue, userRoleValue] = await AsyncStorage.multiGet(['selectedRole', 'userRole']);
+        const selectedRole = selectedRoleValue[1] || userRoleValue[1];
         console.log('selectedRole:', selectedRole);
 
         if (!selectedRole) {
@@ -75,6 +78,10 @@ export default function SplashScreenComponent() {
             router.replace('/auth/role-selection');
           }
           return;
+        }
+
+        if (!userRoleValue[1]) {
+          await AsyncStorage.setItem('userRole', selectedRole);
         }
 
         // Step 3: Check authentication status

--- a/docs/bug-fixes/EXPO_ANDROID_STARTUP_FIX.md
+++ b/docs/bug-fixes/EXPO_ANDROID_STARTUP_FIX.md
@@ -1,0 +1,34 @@
+# Expo Android startup recovery
+
+This project includes helper scripts for the two startup failures that commonly block Android development:
+
+- Corrupted Metro file-map/cache data (`Unable to deserialize cloned data`).
+- Expo CLI dependency validation failing while offline or behind a VPN/proxy/firewall (`TypeError: fetch failed` from `getNativeModuleVersionsAsync`).
+
+## Start Android normally
+
+```bash
+npm run start:android
+```
+
+## Clear Expo/Metro caches and start Android
+
+```bash
+npm run start:android:clear
+```
+
+The cache cleaner removes the project `.expo` directory, `node_modules/.cache`, and common OS temp folders used by Metro, Haste, React Native, and Expo.
+
+## Start Android when Expo dependency validation cannot reach the network
+
+```bash
+npm run start:android:offline
+```
+
+This command performs the same cache cleanup and starts Android with `EXPO_NO_DEPENDENCY_VALIDATION=1`, which lets Expo start without fetching the remote native module compatibility table.
+
+Use this only as a development bypass. When the network is healthy, run `npx expo doctor` or `npx expo install --fix` to verify package compatibility.
+
+## App routing safeguards
+
+The startup flow now normalizes the legacy `selectedRole` AsyncStorage key into the current `userRole` key and routes merchants to `/home/merchant`, which exists in the app. This avoids blank-screen-like redirect loops caused by mismatched role storage keys or redirects to missing routes.

--- a/package.json
+++ b/package.json
@@ -3,13 +3,17 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "start": "expo start --web --port 5000",
+    "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "node --conditions=react-native --no-warnings ./node_modules/expo/bin/cli start --web --port 5000",
     "dev": "node --conditions=react-native --no-warnings ./node_modules/expo/bin/cli start --web --port 5000",
     "test": "jest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "start:web": "expo start --web --port 5000",
+    "start:android": "node scripts/start-expo.js --android",
+    "start:android:clear": "node scripts/clear-expo-cache.js && node scripts/start-expo.js --android --clear",
+    "start:android:offline": "node scripts/clear-expo-cache.js && node scripts/start-expo.js --android --clear --offline-validation"
   },
   "jest": {
     "preset": "jest-expo"

--- a/scripts/clear-expo-cache.js
+++ b/scripts/clear-expo-cache.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '..');
+const tempRoot = os.tmpdir();
+
+const explicitTargets = [
+  path.join(projectRoot, '.expo'),
+  path.join(projectRoot, 'node_modules', '.cache'),
+];
+
+const tempPrefixes = ['metro-', 'haste-map-', 'react-', 'expo-'];
+
+function removeTarget(targetPath) {
+  try {
+    fs.rmSync(targetPath, { recursive: true, force: true });
+    console.log(`Removed ${targetPath}`);
+  } catch (error) {
+    console.warn(`Could not remove ${targetPath}: ${error.message}`);
+  }
+}
+
+for (const target of explicitTargets) {
+  removeTarget(target);
+}
+
+try {
+  for (const entry of fs.readdirSync(tempRoot)) {
+    if (tempPrefixes.some((prefix) => entry.startsWith(prefix))) {
+      removeTarget(path.join(tempRoot, entry));
+    }
+  }
+} catch (error) {
+  console.warn(`Could not scan temp cache directory ${tempRoot}: ${error.message}`);
+}
+
+console.log('Expo and Metro cache cleanup complete. Start Expo with --clear next.');

--- a/scripts/start-expo.js
+++ b/scripts/start-expo.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+
+const rawArgs = process.argv.slice(2);
+const args = rawArgs.filter((arg) => arg !== '--offline-validation');
+const disableDependencyValidation = rawArgs.includes('--offline-validation');
+const expoCliPath = require.resolve('expo/bin/cli');
+
+const child = spawn(process.execPath, [expoCliPath, 'start', ...args], {
+  stdio: 'inherit',
+  shell: false,
+  env: {
+    ...process.env,
+    ...(disableDependencyValidation ? { EXPO_NO_DEPENDENCY_VALIDATION: '1' } : {}),
+  },
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
### Motivation
- Prevent startup redirect loops and blank screens by normalizing legacy AsyncStorage keys and ensuring redirects point to existing routes. 
- Make splash and auth-state routing more robust by handling AsyncStorage and splash API failures gracefully. 
- Improve developer experience for Android by adding cache-cleanup and offline-friendly Expo start helpers and documenting the recovery steps. 

### Description
- Update auth routing in `app/_layout.tsx` to catch AsyncStorage errors, read both `userRole` and legacy `selectedRole` with `AsyncStorage.multiGet`, normalize the stored role, and redirect merchants to `/home/merchant`. 
- Harden onboarding/auth flow in `app/index.tsx` by catching `SplashScreen.preventAutoHideAsync()` failures, using `AsyncStorage.multiGet` to normalize role keys and persist `userRole` when needed, and clearing expired tokens during splash routing. 
- Add developer tooling and docs: new `scripts/clear-expo-cache.js` and `scripts/start-expo.js` to clear Metro/Expo caches and start Expo with an `--offline-validation` bypass, update `package.json` scripts (`start`, `start:android`, `start:android:clear`, `start:android:offline`, etc.), and add `docs/bug-fixes/EXPO_ANDROID_STARTUP_FIX.md` describing recovery commands and the routing safeguard. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a483cdf62a48331b3fc5694cee3331c)